### PR TITLE
Add xml-twig-tools

### DIFF
--- a/install-pkgs.sh
+++ b/install-pkgs.sh
@@ -60,6 +60,7 @@ uuid-dev
 wapiti
 wget
 whiptail
+xml-twig-tools
 xsltproc
 EOF
 } | xargs apt-get install -yq --no-install-recommends


### PR DESCRIPTION
The system is expecting xml_split binary to be installed. 
http://manpages.ubuntu.com/manpages/trusty/man1/xml_split.1p.html

```bash
$ docker run --name openvas2 immauss/openvas
.....
Starting Greenbone Security Assistant...
++++++++++++++++++++++++++++++++++++++++++++++
+ Your GVM 11 container is now ready to use! +
++++++++++++++++++++++++++++++++++++++++++++++

++++++++++++++++
+ Tailing logs +
++++++++++++++++
....
==> /usr/local/var/log/gvm/gvmd.log <==
....
md manage:   INFO:2020-07-30 15h44.55 utc:544: update_dfn_xml: dfn-cert-2015.xml
md manage:   INFO:2020-07-30 15h44.55 utc:544: Updating /usr/local/var/lib/gvm/cert-data/dfn-cert-2015.xml
md manage:   INFO:2020-07-30 15h45.01 utc:544: update_dfn_xml: dfn-cert-2019.xml
md manage:   INFO:2020-07-30 15h45.01 utc:544: Updating /usr/local/var/lib/gvm/cert-data/dfn-cert-2019.xml
md manage:   INFO:2020-07-30 15h45.05 utc:576: update_scap: Updating data from feed
md manage:   INFO:2020-07-30 15h45.05 utc:576: Updating CPEs
sh: 1: xml_split: not found
md manage:WARNING:2020-07-30 15h45.05 utc:576: split_xml_file: system failed with ret 32512, 127, xml_split -s40Mb split.xml && head -n 2 split-00.xml > head.xml && echo '</cpe-list>' > tail.xml && for F in split-*.xml; do    tail -n +3 $F    | head -n -1    | cat head.xml - tail.xml    > new.xml;    mv new.xml $F;    done
md manage:WARNING:2020-07-30 15h45.05 utc:576: split_xml_file: and failed to chdir back
md manage:WARNING:2020-07-30 15h45.05 utc:576: update_scap_cpes: Failed to split CPEs, attempting with full file
...
```