### PR TITLE
Update start.sh

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -120,6 +120,11 @@ sed -i "s/ltvrP/ltrP/" /usr/local/sbin/greenbone-scapdata-sync
 sed -i "s/ltvrP/ltrP/" /usr/local/sbin/greenbone-certdata-sync
 
 echo "Updating NVTs..."
+if [ -f /usr/local/var/run/feed-update.lock ]; then
+        # If NVT updater crashes it does not clear this up without intervention
+        echo "Removing feed-update.lock"
+	rm /usr/local/var/run/feed-update.lock
+fi
 #su -c "rsync --compress-level=9 --links --times --omit-dir-times --recursive --partial --quiet rsync://feed.community.greenbone.net:/nvt-feed /usr/local/var/lib/openvas/plugins" openvas-sync
 su -c "/usr/local/bin/greenbone-nvt-sync" openvas-sync
 sleep 5


### PR DESCRIPTION
I had a container crash on me mid update to the NVTs and I couldn't clear this without manually removing the lock file. Kept telling me an update was in progress... it wasn't as the whole host the container sits on had died.

There might be a better way or more checks but if you want to sort it I'm assuming start.sh would only be running on a container restart so it actually running would be a false positive.