### PR TITLE
Disable deprecated ciphers, Add support for HTTP to HTTPS redirects.

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -411,8 +411,7 @@ echo "Starting Greenbone Security Assistant..."
 #su -c "gsad --verbose --http-only --no-redirect --port=9392" gvm
 if [ $HTTPS == "true" ]; then
 	su -c "gsad --mlisten 127.0.0.1 -m 9390 --verbose --timeout=$GSATIMEOUT \
-	            --gnutls-priorities=SECURE128:-AES-128-CBC:-CAMELLIA-128-CBC:-VERS-SSL3.0:-VERS-TLS1.0 \
-		    --no-redirect \
+	            --gnutls-priorities=SECURE128:+SECURE192:-VERS-TLS-ALL:+VERS-TLS1.2 \
 		    --port=9392" gvm
 else
 	su -c "gsad --mlisten 127.0.0.1 -m 9390 --verbose --timeout=$GSATIMEOUT --http-only --no-redirect --port=9392" gvm


### PR DESCRIPTION
* Enable HTTP to HTTPS redirects. When using HTTPS=true
* Disable deprecated TLS versions. Only allow TLS 1.2

When running OpenVAS against OpenVAS I noticed that it shows a medium critical result based on the ciphers used by the start.sh script. 

The following site: https://docs.huihoo.com/gnutls/3.4.3/manual/Priority-Strings.html recommends using: 

```
Enabling the 128-bit and 192-bit secure ciphers, while disabling all TLS versions except TLS 1.2:
    "SECURE128:+SECURE192:-VERS-TLS-ALL:+VERS-TLS1.2"
```