### PR TITLE
Fix issue that the container will always run the fs-setup.sh script on startup

### DIFF
--- a/scripts/fs-setup.sh
+++ b/scripts/fs-setup.sh
@@ -134,4 +134,4 @@ chmod 777 /run
 chown -R postfix:postfix /var/lib/postfix
 
 
-touch /.fs-setup-complete
+touch /data/.fs-setup-complete

--- a/scripts/gvmd.sh
+++ b/scripts/gvmd.sh
@@ -186,7 +186,7 @@ sed -i "s/^relayhost.*$/relayhost = ${RELAYHOST}:${SMTPPORT}/" /etc/postfix/main
 # Start the postfix  bits
 #/usr/lib/postfix/sbin/master -w
 service postfix start
-tail -f /usr/local/var/log/gvm/gvmd.log &
+tail -F /usr/local/var/log/gvm/gvmd.log &
 #WTF ???? Why did I do this?
 pkill gvmd
 su -c "exec gvmd -f $GMP --listen-group=gvm  --osp-vt-update=/run/ospd/ospd.sock --max-email-attachment-size=64000000 --max-email-include-size=64000000 --max-email-message-size=64000000" gvm

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #set -Eeuo pipefail
-if ! [ -f /.fs-setup-complete ]; then
+if ! [ -f /data/.fs-setup-complete ]; then
 	echo "Setting up contianer filesystem"
 	/scripts/fs-setup.sh
 else


### PR DESCRIPTION
In our docker swarm the container will alway execute the fs-setup.sh script because the .fs-setup-complete script wouldn't be on a volume that is persistent