### PR TITLE
fix path

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -3,10 +3,10 @@ echo " Pulling NVTs from greenbone"
 su -c "/usr/local/bin/greenbone-nvt-sync" gvm
 sleep 2
 echo " Pulling scapdata from greenbone"
-su -c "/usr/local/sbin/greenbone-feed-sync --type SCAP" gvm
+su -c "/usr/local/bin/greenbone-feed-sync --type SCAP" gvm
 sleep 2
 echo " Pulling cert-data from greenbone"
-su -c "/usr/local/sbin/greenbone-feed-sync --type CERT" gvm
+su -c "/usr/local/bin/greenbone-feed-sync --type CERT" gvm
 sleep 2
 echo " Pulling latest GVMD Data from Greenbone" 
-su -c "/usr/local/sbin/greenbone-feed-sync --type GVMD_DATA " gvm
+su -c "/usr/local/bin/greenbone-feed-sync --type GVMD_DATA " gvm


### PR DESCRIPTION
Sync script only ever updated NVTs and error-ed out on scap, cert and GVMD data sync due to incorrect path. Not sure why nobody noticed so far. Syncing did only work with sync on startup (SKIPSYNC=false) due to the `--type all` argument used [here](https://github.com/immauss/openvas/blob/d64cd0f951c4ea5845408f938756817ad2a4c3d1/scripts/single.sh#L270).