### PR TITLE
uncommented EXPOSE 9392

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ LABEL maintainer="scott@immauss.com" \
       version="$VER-slim" \
       url="https://hub.docker.com/r/immauss/openvas" \
       source="https://github.com/immauss/openvas"     
-#EXPOSE 9392
+EXPOSE 9392
 ENV LANG=C.UTF-8
 # Copy the install from stage 0
 # Move all of this to a sinlge "build" folder and reduce the number of layers by copying the 


### PR DESCRIPTION
The expose line was commented. Docker-Desktops can't publish ports, which aren't exposed in the Dockerfile.


