### PR TITLE
Update single.sh - Added MTA auth processing

### DIFF
--- a/scripts/single.sh
+++ b/scripts/single.sh
@@ -13,6 +13,9 @@ USERNAME=${USERNAME:-admin}
 PASSWORD=${PASSWORD:-admin}
 RELAYHOST=${RELAYHOST:-172.17.0.1}
 SMTPPORT=${SMTPPORT:-25}
+MTA_AUTH=${MTA_AUTH:-false}
+MTA_USER=${MTA_USER:-blank}
+MTA_PASSWORD=${MTA_PASSWORD:-blank}
 REDISDBS=${REDISDBS:-512}
 QUIET=${QUIET:-false}
 # use this to rebuild the DB from scratch instead of using the one in the image.
@@ -31,7 +34,7 @@ if [ $GVMD_ARGS == "blank" ]; then
 	GVMD_ARGS='--'
 fi
 if [ "$DEBUG" == "true" ]; then
-	for var in USERNAME PASSWORD RELAYHOST SMTPPORT REDISDBS QUIET CREATE_EMPTY_DATABASE SKIPSYNC RESTORE DEBUG HTTPS GSATIMEOUT SKIPGSAD; do 
+	for var in USERNAME PASSWORD RELAYHOST SMTPPORT MTA_AUTH MTA_USER MTA_PASSWORD REDISDBS QUIET CREATE_EMPTY_DATABASE SKIPSYNC RESTORE DEBUG HTTPS GSATIMEOUT SKIPGSAD; do 
 		echo "$var = ${var}"
 	done
 fi
@@ -398,7 +401,21 @@ smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 smtp_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 smtp_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1" >> /etc/postfix/main.cf
-
+if [ ${MTA_AUTH} == "TRUE" ] || [ ${MTA_AUTH} == "true"  ]; then
+    echo "Enabling SMTP authentication"
+    echo "smtp_sasl_auth_enable = yes
+smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
+smtp_sasl_security_options = noanonymous
+smtp_sasl_tls_security_options = noanonymous" >> /etc/postfix/main.cf
+    if ! [ -f /etc/postfix/sasl_passwd ]; then
+        touch /etc/postfix/sasl_passwd
+        echo "${RELAYHOST}:${SMTPPORT} ${MTA_USER}:${MTA_PASSWORD}" > /etc/postfix/sasl_passwd
+    elif ! grep -Fxq "${RELAYHOST}:${SMTPPORT} ${MTA_USER}:${MTA_PASSWORD}" /etc/postfix/sasl_passwd; then
+        echo "${RELAYHOST}:${SMTPPORT} ${MTA_USER}:${MTA_PASSWORD}" >> /etc/postfix/sasl_passwd
+    fi
+    chmod 600 /etc/postfix/sasl_passwd
+    postmap /etc/postfix/sasl_passwd
+fi
 # Start the postfix  bits
 #/usr/lib/postfix/sbin/master -w
 service postfix start


### PR DESCRIPTION
Hello.
We have faced with case when we need to use MTA authentication. 
According to Greenbone docs - https://greenbone.github.io/docs/latest/22.4/container/workflows.html#id22 - they are using gvmd with msmtp client as MTA. And something like this should be used (if using Docker):
      - MTA_HOST=smtp.gmail.com
      - MTA_PORT=587
      - MTA_TLS=on
      - MTA_STARTTLS=on
      - MTA_AUTH=on
      - MTA_USER=<username>
      - MTA_PASSWORD=<some_password>
      - MTA_FROM=<username>@gmail.com
 
 As far as I understand you have reworked this part and used Postfix with only two parameters - RELAYHOST and SMTPPORT.
I have made some refactoring of single.sh script to make MTA authentication be available. Considering that:

- MTA_HOST and MTA_PORT = RELAYHOST and SMTP_PORT (from your script parameter)

- MTA_TLS and MTA_STARTTLS are already set up by default and due to "#Make postfix more secureish thanks @rkoosaar" in your code

- MTA_AUTH, MTA_USER and MTA_PASSWORD are not processed and can be configured in /etc/postfix/main.cf as:
smtp_sasl_auth_enable = yes
smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
smtp_sasl_security_options = noanonymous
smtp_sasl_tls_security_options = noanonymous

where /etc/postfix/sasl_passwd contents is :
${RELAYHOST}:${SMTPPORT} ${MTA_USER}:${MTA_PASSWORD}

and secured with "chmod 600 /etc/postfix/sasl_passwd && postmap /etc/postfix/sasl_passwd"

- MTA_FROM is set in alert config in OpenVAS (in "From Address" field)
 
So, minor additions to your single.sh script allows to use MTA authentication.
Please, review and, if possible, accept pull request.
With best regards, Bogdan