### PR TITLE
fix(scripts/single.sh): remove invalid empty-db startup command and correct debug/error logging

### DIFF
--- a/scripts/single.sh
+++ b/scripts/single.sh
@@ -48,7 +48,7 @@ if [ $GVMD_ARGS == "blank" ]; then
 fi
 if [ "$DEBUG" == "true" ]; then
 	for var in USERNAME PASSWORD RELAYHOST SMTPPORT REDISDBS QUIET CREATE_EMPTY_DATABASE SKIPSYNC RESTORE DEBUG HTTPS GSATIMEOUT SKIPGSAD; do 
-		echo "$var = ${var}"
+		echo "$var = ${!var}"
 	done
 fi
 
@@ -105,7 +105,7 @@ echo "Starting PostgreSQL..."
 su -c "/usr/lib/postgresql/${PGVER}/bin/pg_ctl -D /data/database start" postgres || PGFAIL=$?
 echo "pg exit with $PGFAIL ." 
 if [ $PGFAIL -ne 0 ]; then
-	echo "It looks like postgres failed to start. ( Exit code: \"$?\" "
+	echo "It looks like postgres failed to start. ( Exit code: \"$PGFAIL\" )"
 	echo "Assuming this is due to different database version and starting upgrade."
 	#/scripts/db-upgrade.sh || PGUPFAIL=$?
 	/scripts/pg13-2-15.sh || PGUPFAIL=$?
@@ -199,8 +199,6 @@ if [ $CREATE_EMPTY_DATABASE = "true" ]; then
 		su -c "gvm-manage-certs -V " gvm 
 		NOCERTS=$?
 	done
- --rebuild-gvmd-data=report_formats
-
 fi
 # if RESTORE is true, hopefully the user has mounted thier database in the right place.
 if [ $RESTORE = "true" ] ; then


### PR DESCRIPTION
**Describe the bug**
When `CREATE_EMPTY_DATABASE=true` (or `NEWDB=true`), `scripts/single.sh` fails during startup because the script contains a stray line:

  --rebuild-gvmd-data=report_formats

That line is not a shell command and aborts the script.

**To Reproduce**
1. Start the container with `NEWDB=true` or `CREATE_EMPTY_DATABASE=true`.
2. Use a Docker command or `docker-compose.yml` with the env var set.
3. Watch the startup logs for the failure during the empty DB creation stage.

**Expected behavior**
The container should finish empty DB creation and continue startup.

**Environment**
- OS: [e.g. Ubuntu 20.10]
- Memory available to OS: [ 4G ]
- Container environment used with version: [ docker ]

**Additional context**
- The bug is in `scripts/single.sh` in the `CREATE_EMPTY_DATABASE` branch.
- There is also a debug-print bug with `${var}` instead of `${!var}`.
- The postgres failure message uses `$?` incorrectly instead of `$PGFAIL`.

**Resolution**
Remove or fix the stray command:
```bash
--rebuild-gvmd-data=report_formats