### PR TITLE
fix(startup): correct report format rebuild command during empty DB i…

### DIFF
--- a/scripts/single.sh
+++ b/scripts/single.sh
@@ -199,7 +199,7 @@ if [ $CREATE_EMPTY_DATABASE = "true" ]; then
 		su -c "gvm-manage-certs -V " gvm 
 		NOCERTS=$?
 	done
- --rebuild-gvmd-data=report_formats
+su -c "gvmd --rebuild-gvmd-data=report_formats" gvm
 
 fi
 # if RESTORE is true, hopefully the user has mounted thier database in the right place.


### PR DESCRIPTION
Description

When CREATE_EMPTY_DATABASE=true (or NEWDB=true), the startup script enters the empty database initialization path to create a fresh Greenbone database.

After successfully creating the PostgreSQL database, generating certificates, and validating the certificates, the script executes the following standalone line:

--rebuild-gvmd-data=report_formats

This line is not a valid shell command because it is not invoked through gvmd (or any other executable). Since the startup script is executed with:

set -Eeuo pipefail

Bash attempts to execute --rebuild-gvmd-data=report_formats as a command, which results in a "command not found" error and causes the startup script to terminate.

This issue only affects the empty database initialization path (CREATE_EMPTY_DATABASE=true / NEWDB=true). Normal startup using the bundled database or an existing persistent database is not affected.

Steps to Reproduce
Start the container with an empty database initialization. docker run \
  -e NEWDB=true \
  ...

or

docker run \
  -e CREATE_EMPTY_DATABASE=true \
  ...
Wait for the container to:
Start PostgreSQL
Create the gvmd database
Generate the required certificates
After the certificate validation loop completes, the script reaches: --rebuild-gvmd-data=report_formats
The startup script exits because the line is treated as an invalid shell command. Current Code

su -c "gvm-manage-certs -V" gvm
NOCERTS=$?
while [ $NOCERTS -ne 0 ]; do
    su -c "gvm-manage-certs -vaf" gvm
    su -c "gvm-manage-certs -V" gvm
    NOCERTS=$?
done

--rebuild-gvmd-data=report_formats

Expected Behavior

The container should complete the empty database initialization successfully and continue with the remaining startup process without terminating.

Proposed Fix

Replace the standalone line with a valid gvmd invocation:

su -c "gvmd --rebuild-gvmd-data=report_formats" gvm

Alternatively, if rebuilding report formats is intended to occur later during initialization, the standalone line can simply be removed.

Environment
Docker deployment
Empty database initialization (NEWDB=true / CREATE_EMPTY_DATABASE=true) Startup script: scripts/single.sh

Additional Notes

I verified that replacing the standalone line with:

su -c "gvmd --rebuild-gvmd-data=report_formats" gvm

allows the script to continue past this point without encountering the shell error.

The issue appears to be an accidental standalone command rather than an intended shell statement, since the same gvmd --rebuild-gvmd-data=report_formats command is already invoked correctly elsewhere in the startup script after a database restore.